### PR TITLE
Disable edit feature due to the latest docs architecture

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,6 @@ site_name: SiloGen documentation
 site_description: Documentation for SiloGen AMD Enterprise AI Platform
 repo_url: https://github.com/silogen/docs
 docs_dir: docs
-edit_uri: https://github.com/silogen/docs/blob/main
 
 theme:
   icon: material/developer-board
@@ -36,7 +35,6 @@ theme:
         name: Switch to system preference
 
   features:
-    - content.action.edit
     - content.code.copy
     - navigation.indexes
     - navigation.tabs


### PR DESCRIPTION
Disable editing feature since our current documentation architecture isn't friendly for external editing.