### PR TITLE
Add a proto test for Macros plugin

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
-# SiloGen - AMD Enterprise AI Platform documentation
+# {{ name_verylong }} documentation
 
-Welcome to the documentation for SiloGen - AMD Enterprise AI Platform. Enterprises striving to scale AI often encounter roadblocks that increase costs, slow innovation, and limit impact. The AMD Enterprise AI stack is built to overcome these challenges and unlock the full potential of AI across the enterprise.
+Welcome to the documentation for {{ name_verylong }}. Enterprises striving to scale AI often encounter roadblocks that increase costs, slow innovation, and limit impact. The AMD Enterprise AI stack is built to overcome these challenges and unlock the full potential of AI across the enterprise.
 
 This is your comprehensive handbook designed to help infrastructure administrators, AI practitioners, and AI resource managers successfully deploy, manage, and run AI workloads on AMD compute. The guide provides step-by-step instructions for installing and configuring the necessary software, as well as practical tutorials and use cases to help you run AI workloads efficiently on a scalable Kubernetes platform.
 
@@ -16,7 +16,7 @@ This is your comprehensive handbook designed to help infrastructure administrato
 
       <ul class="intro-links">
         <li>
-          <a href="./platform-overview/">SiloGen platform overview</a>
+          <a href="./platform-overview/">{{ name_mid }} overview</a>
         </li>
         <li>
           <a href="./quick-start/">Quick start guide</a>

--- a/docs/target-audience.md
+++ b/docs/target-audience.md
@@ -4,12 +4,12 @@ tags:
   - target audience
 ---
 
-# Target audience of the SiloGen platform
+# Target audience of the {{ name_mid }}
 
-The SiloGen platform and this documentation are designed for three user personas, each focusing on different layers and aspects of the AI technology stack and lifecycle.
+The {{ name_mid }} and this documentation are designed for three user personas, each focusing on different layers and aspects of the AI technology stack and lifecycle.
 
 - **Infrastructure administrators**: Professionals responsible for setting up, maintaining, and optimizing the infrastructure that supports AI workloads.
 - **AI resource managers**: Professionals responsible for granting access to compute resources, maintaining projects, users, and optimizing AI resources.
 - **AI practitioners**: Professionals who train, deploy, and manage AI models and applications in an enterprise environment.
 
-While some familiarity with Kubernetes, containerization, and AI/ML concepts is helpful, this handbook provides detailed instructions and explanations to accommodate users with varying levels of expertise. The handbook guides you to set up a fully deployed SiloGen Enterprise AI platform optimized for AI workloads on AMD compute and provides the knowledge needed to run and manage AI use cases effectively.
+While some familiarity with Kubernetes, containerization, and AI/ML concepts is helpful, this handbook provides detailed instructions and explanations to accommodate users with varying levels of expertise. The handbook guides you to set up a fully deployed {{ name_long }} optimized for AI workloads on AMD compute and provides the knowledge needed to run and manage AI use cases effectively.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,7 @@ theme:
 plugins:
   - search
   - tags
+  - macros
   # - with-pdf
 
   - redirects:
@@ -157,6 +158,12 @@ nav:
   - References:
     - References: references/overview.md
     - Tags: references/tags.md
+
+extra:
+  name: SiloGen
+  name_mid: SiloGen platform
+  name_long: SiloGen Enterprise AI platform
+  name_verylong: SiloGen - AMD Enterprise AI Platform
 
 extra_css:
   - stylesheets/extra.css

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pymdown-extensions>=9.0
 mkdocs-include-markdown-plugin>=7.1.4
 mkdocs-with-pdf>=0.9.3
 mkdocs-redirects>=1.2.2
+mkdocs-macros-plugin>=1.3.9


### PR DESCRIPTION
Create a proto level test of Macros plugin in Mkdocs. The plugin allows the usage of variables, that are declared in the mkdocs.yml file's `extra` section. To test, install pip requirements and launch Mkdocs serve. The initial name variables are tested in two separate files. See how we already have four different names for the platform (well the plain name variable isn't used anywhere).